### PR TITLE
Implement Context.Embed and Simplify Username Reference

### DIFF
--- a/src/Xylox.Discord/Commands/Modules/Ping.cs
+++ b/src/Xylox.Discord/Commands/Modules/Ping.cs
@@ -9,12 +9,12 @@ namespace Xylox.Discord.Commands.Modules
         [Command("Ping")]
         public async Task PingCommand()
         {
-            var embed = new EmbedBuilder()
+            Context.Embed
                 .WithAuthor($"Ohia {Context.User.ToString()}")
                 .WithDescription("Pong!")
                 .WithColor(Color.DarkMagenta);
 
-            await ReplyEmbedAsync(embed);
+            await ReplyEmbedAsync(Context.Embed);
         }
     }
 }

--- a/src/Xylox.Discord/Commands/Modules/Ping.cs
+++ b/src/Xylox.Discord/Commands/Modules/Ping.cs
@@ -10,7 +10,7 @@ namespace Xylox.Discord.Commands.Modules
         public async Task PingCommand()
         {
             var embed = new EmbedBuilder()
-                .WithAuthor($"Ohia {Context.User.Username}#{Context.User.Discriminator}")
+                .WithAuthor($"Ohia {Context.User.ToString()}")
                 .WithDescription("Pong!")
                 .WithColor(Color.DarkMagenta);
 


### PR DESCRIPTION
A couple of minor changes, but Context.User.ToString() is what $"{Context.User.Username}#{Context.User.Discriminator}" does. I also noticed that Context.Embed wasn't being utilized, so I changed the code to now account for that. Honestly, the code is in a pretty good state as of now, and all I could think of at the moment was:
- Separate DiscordSocketConfig and CommandServiceConfig into their own static constructor classes for reference.
- 'Async' being added onto the name of asynchronous tasks (i.e. Run => RunAsync)